### PR TITLE
Bugfix/improve historic playback

### DIFF
--- a/spec/make_ord_spec.cr
+++ b/spec/make_ord_spec.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "../src/color_diff.cr"
 require "../src/layouts.cr"
 
 describe "make ord" do

--- a/src/layouts.cr
+++ b/src/layouts.cr
@@ -264,7 +264,7 @@ class DefaultLayout < Layout
     else
       max_balls = game["homeBalls"].as_i?
       max_strikes = game["homeStrikes"].as_i?
-      max_outs = game["awayOuts"].as_i?
+      max_outs = game["homeOuts"].as_i?
       number_of_bases_including_home = game["homeBases"].as_i?
     end
 

--- a/src/layouts.cr
+++ b/src/layouts.cr
@@ -150,7 +150,7 @@ class DefaultLayout < Layout
           return team_name
         end
       end
-      raise "Team with id #{target_team_id} not found in sim league object"
+      return "Unknown Team"
     else
       return away ? game[away_game_identifier].to_s : game[home_game_identifier].to_s
     end

--- a/src/layouts.cr
+++ b/src/layouts.cr
@@ -249,7 +249,11 @@ class DefaultLayout < Layout
         end
         m << ".\r\n"
 
-        m << make_newlines(game["lastUpdate"].as_s)
+        last_update = make_newlines(game["lastUpdate"].as_s)
+        m << last_update
+        if !last_update.ends_with?("\r\n")
+          m << "\r\n"
+        end
       end
     end
   end

--- a/src/layouts.cr
+++ b/src/layouts.cr
@@ -287,15 +287,15 @@ class DefaultLayout < Layout
       bases_occupied = bases_occupied.map { |b| b.as_i }
       m << ". #{bases_occupied.size} on ("
 
-      number_bases = bases_occupied.max
-      if number_of_bases_including_home && number_bases < number_of_bases_including_home
-        number_bases = number_of_bases_including_home
+      number_bases = bases_occupied.max + 1
+      if number_of_bases_including_home && number_bases < (number_of_bases_including_home - 1)
+        number_bases = number_of_bases_including_home - 1
       end
-      if number_bases < 4
-        number_bases = 4
+      if number_bases < 3
+        number_bases = 3
       end
 
-      bases = Array.new(number_bases - 1, 0)
+      bases = Array.new(number_bases, 0)
       bases_occupied.each do |b|
         bases[b] += 1
       end

--- a/src/layouts.cr
+++ b/src/layouts.cr
@@ -247,6 +247,8 @@ class DefaultLayout < Layout
         end
       end
     end
+
+    m << "\r\n"
   end
 
   def render_game_status(

--- a/src/server.cr
+++ b/src/server.cr
@@ -164,9 +164,15 @@ while data = tx.receive?
     end
   end
 
-  if data[0] != "live" && sources[data[0]].n_clients < 1
-    sources[data[0]].close
-    sources.delete data[0]
+  if data[0] != "live"
+    begin
+      if sources[data[0]].n_clients < 1
+        sources[data[0]].close
+        sources.delete data[0]
+      end
+    rescue ex
+      pp ex.inspect_with_backtrace
+    end
   end
 
   sockets -= to_delete

--- a/src/sources.cr
+++ b/src/sources.cr
@@ -158,8 +158,6 @@ class ChroniclerSource < Source
   end
 
   def fetch_messages
-    puts "fetching messages"
-
     url = URI.parse(ENV["CHRONICLER_URL"] ||= "https://api.sibr.dev/chronicler/")
     url.query = URI::Params.encode({"type" => "Stream", "count" => "30", "order" => "asc", "after" => @last_time.to_rfc3339})
     url.path = (Path.new(url.path) / "v2" / "versions").to_s


### PR DESCRIPTION
Chron requests were appending to URL -- now fetching ENV for all request (couldn't find a URI clone constructor).
Stopped assuming HTTP request will succeed -- log if it fails.
Fix which team's outs is used.
Fix base display when more than one base exists. 
Force space at end of lastUpdate -- previously no whitespace between lines in Expansion/Discipline games